### PR TITLE
VSCode debugging and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.py[cod]
 venv/
+.vscode/settings.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,25 +1,18 @@
 {
     "version": "0.2.0",
-    "configurations": [{
-        "name": "Flask",
+    "configurations": [
+        {
+            "name": "Python",
         "type": "python",
         "request": "launch",
         "stopOnEntry": false,
         "pythonPath": "${config.python.pythonPath}",
-        "program": "${workspaceRoot}/venv/bin/flask",
-        "cwd": "${workspaceRoot}",
-        "env": {
-            "FLASK_APP": "${workspaceRoot}/main.py"
-        },
-        "args": [
-            "run",
-            "--no-debugger",
-            "--no-reload"
-        ],
+            "program": "${workspaceRoot}/main.py",
         "debugOptions": [
             "WaitOnAbnormalExit",
             "WaitOnNormalExit",
             "RedirectOutput"
         ]
-    }]
+        }
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "python.pythonPath": "${workspaceRoot}/venv/bin/python2.7"
-}

--- a/README.md
+++ b/README.md
@@ -1,10 +1,119 @@
 # Quick Start for Python Google App Engine
 
-## app.yaml
+## Setup
 
-Deploys to `standard` or `flex` app engine.
+### Ensure Python 2.7 is on your path:
+```
+python --version
+```
+If missing or wrong version, install from [https://www.python.org/downloads/](https://www.python.org/downloads/) and add to your path.
 
-## Simulators
+### Create a virtual environment
+- Verify that `virtualenv` is installed:
+```
+virtualenv --help
+```
+
+- If it is not installed, installed it with `pip`:
+```
+pip install virtualenv
+```
+
+- Create the virtual environment `venv`
+```
+virtualenv venv
+```
+
+- Activate the virtual environment
+    - Windows DOS command: `venv\scripts\activate.bat`
+    - Windows Powershell: `venv\scripts\activate.ps1`
+    - Bash: `venv\bin\activate`
+
+### Install requirements
+```
+pip install -r requirements.txt
+```
+
+## Run locally
+
+From command line (DOS, Powershell, bash):
+```
+python main.py
+```
+
+## Using Visual Studio Code
+
+### Setup
+- Install [Python extension](https://marketplace.visualstudio.com/items?itemName=donjayamanne.python):
+    Launch VS Code Quick Open (Ctrl+P), paste the following command, and press enter
+    ```ext install python```
+- Read extension [documentation](https://github.com/DonJayamanne/pythonVSCode/wiki) and particular, the documentation about 
+[linting](https://github.com/DonJayamanne/pythonVSCode/wiki/Linting).
+
+
+### Using environment
+To let Visual Studio code find the correct python interpreter and libraries for debugging and intellisense.
+- From the command line (with virtual environment activated): environment picked automatically
+    ``` vscode . ```
+- When opening Visual Studio Code from file explorer (Open with Code menu):
+    Set the environment from the [command palette](https://code.visualstudio.com/docs/editor/codebasics#_command-palette): `Ctrl+Shift+P`
+    ```
+    python select workspace interpreter
+    ```
+    Choose the `python` executable under your local `venv` directory.
+
+### Debugging
+Like Visual Studio, press `F9` to set a break point, `F5` to start debugging
+There are [diffent ways to debug Flask](https://github.com/DonJayamanne/pythonVSCode/wiki/Debugging:-Flask).
+This example is setup for [Flask debugging solution 2](https://github.com/DonJayamanne/pythonVSCode/wiki/Debugging:-Flask#solution-2).
+
+## Deploy
+
+### Ensure that your Google configuration points to the correct project
+```
+gcloud config list
+```
+### Setup site packages for deployment
+** Windows setup is different from Linux/Mac**
+- In [appengine_config.py](./appengine_config.py)
+    - Mac/Linux
+    ```python
+    vendor.add('venv/lib/python2.7/site-packages')
+    ```
+    - Windows
+    ```python
+    vendor.add('venv/Lib/site-packages')
+    ```  
+- In [app.std.yaml](./app.std.yaml)
+  - Mac/Linux
+  ```yaml
+  skip_files:
+  - (venv/lib/python2.7/site-packages/appengine_sdk.*)
+  - (venv/lib/python2.7/site-packages/setuptools/.*)
+  - (venv/lib/python2.7/site-packages/nose.*)
+  - (venv/lib/python2.7/site-packages/pip.*)
+  ```
+  - Windows
+  ```yaml
+  skip_files:
+  - (venv/Lib/site-packages/appengine_sdk.*)
+  - (venv/Lib/site-packages/setuptools/.*)
+  - (venv/Lib/site-packages/nose.*)
+  - (venv/Lib/site-packages/pip.*)
+  ```
+
+### Deploy to Standard App Engine
+```
+gcloud app deploy --version=v1 app.std.yaml
+```
+
+## Browse
+- Service: `https://talk-demo-dot-<projectname>.appspot.com`
+    - You can also use `gcloud app browse -s talk-demo`
+- default: `https://<projectname>.appspot.com`
+    - You can also use `gcloud app browse`
+
+## Emulators
 
 ```bash
 gcloud beta emulators datastore start &
@@ -20,27 +129,4 @@ unset PUBSUB_EMULATOR_HOST
 
 ```
 
-## Setup
-
-```
-virtualenv venv
-
-# windows
-venv\scripts\activate.bat
-
-# bash
-
-pip install -r requirements.txt
-
-python main.py
-
-# deploy
-gcloud app deploy --project=the-depot --version=v1 ./app.std.yaml
-
-# browse to
-(service) https://talk-demo-dot-<projectname>.appspot.com
-(default) https://<projectname>.appspot.com
-
-
-```
 

--- a/app.std.yaml
+++ b/app.std.yaml
@@ -17,7 +17,13 @@ skip_files:
 - ^(.*/)?\..*$
 
 # These packages are either preinstalled or not needed on the actual deployed application
-- (venv/lib/python2.7/site-packages/appengine_sdk.*)
-- (venv/lib/python2.7/site-packages/setuptools/.*)
-- (venv/lib/python2.7/site-packages/nose.*)
-- (venv/lib/python2.7/site-packages/pip.*)
+# Mac/Linux
+# - (venv/lib/python2.7/site-packages/appengine_sdk.*)
+# - (venv/lib/python2.7/site-packages/setuptools/.*)
+# - (venv/lib/python2.7/site-packages/nose.*)
+# - (venv/lib/python2.7/site-packages/pip.*)
+# Windows
+- (venv/Lib/site-packages/appengine_sdk.*)
+- (venv/Lib/site-packages/setuptools/.*)
+- (venv/Lib/site-packages/nose.*)
+- (venv/Lib/site-packages/pip.*)

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -5,7 +5,7 @@ from google.appengine.ext import vendor
 # (this is set by Google when running on GAE in the cloud)
 if os.getenv('SERVER_SOFTWARE', '').startswith('Google App Engine/'):
     # on mac
-    vendor.add('venv/lib/python2.7/site-packages')
+    # vendor.add('venv/lib/python2.7/site-packages')
 
     # on windows
-    # vendor.add('venv/Lib/site-packages')
+    vendor.add('venv/Lib/site-packages')

--- a/main.py
+++ b/main.py
@@ -69,8 +69,10 @@ def server_error(err):
 if __name__ == '__main__':
     # Used for running locally
     if os.environ.get('VSCODE_PID'):
-        # Debugging from VSCODE, see: https://github.com/DonJayamanne/pythonVSCode/wiki/Debugging:-Flask#solution-2
+        # Debugging from VSCODE, see:
+        # https://github.com/DonJayamanne/pythonVSCode/wiki/Debugging:-Flask#solution-2
+
         app.run(host='127.0.0.1', port=8080, debug=False, use_reloader=False)
     else:
         # From the command line
-    app.run(host='127.0.0.1', port=8080, debug=True)
+        app.run(host='127.0.0.1', port=8080, debug=True)

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@
 import logging
 import json
 import base64
+import os
 
 from flask import Flask, request
 from flask import jsonify
@@ -18,6 +19,7 @@ app = Flask(__name__)
 def hello_world():
     """hello world"""
     return 'Hello World!'
+
 
 @app.route('/pubsub/receive', methods=['POST'])
 def pubsub_receive():
@@ -66,4 +68,9 @@ def server_error(err):
 
 if __name__ == '__main__':
     # Used for running locally
+    if os.environ.get('VSCODE_PID'):
+        # Debugging from VSCODE, see: https://github.com/DonJayamanne/pythonVSCode/wiki/Debugging:-Flask#solution-2
+        app.run(host='127.0.0.1', port=8080, debug=False, use_reloader=False)
+    else:
+        # From the command line
     app.run(host='127.0.0.1', port=8080, debug=True)


### PR DESCRIPTION
- Since you are already using app.run in your main, I changed the .vccode/launch.json to use the simple python launcher (I did put a link on the various ways to debug Flask in README.md
- I updated the documentation with more detailed information on setup and debugging on Windows
- I changed the default settings in app.std.yaml and appengine_config.py to help Windows developers (the majority of people in the hackathon).
- I removed the .vscode/settings.json (and added it to .gitignore) since this is machine specific. Instead, I explained how to set the python configuration from VSCode in README.md (which creates .vscode/settings.json)